### PR TITLE
Added resource and global search on page resource

### DIFF
--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -12,6 +12,8 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Statikbe\FilamentFlexibleContentBlockPages\Actions\LinkedToMenuItemBulkDeleteAction;
 use Statikbe\FilamentFlexibleContentBlockPages\Facades\FilamentFlexibleContentBlockPages;
 use Statikbe\FilamentFlexibleContentBlockPages\Resources\PageResource\Pages\CreatePage;
@@ -46,6 +48,10 @@ class PageResource extends Resource
     protected static ?string $recordRouteKeyName = 'id';
 
     protected static ?string $recordTitleAttribute = 'title';
+
+    protected static int $globalSearchResultsLimit = 10;
+
+    protected static ?bool $isGlobalSearchForcedCaseInsensitive = true;
 
     public static function getModel(): string
     {
@@ -179,12 +185,18 @@ class PageResource extends Resource
     {
         return $table
             ->columns([
-                TitleColumn::create(),
+                TitleColumn::create()
+                ->searchable(query: function($query, $search) {
+                    $locale = app()->getLocale();
+                    $search = strtolower($search);
+                    return $query->whereRaw("LOWER(title->>'$.{$locale}') LIKE ?", ["%{$search}%"]);
+                }),
                 TextColumn::make('created_at')
                     ->label(flexiblePagesTrans('pages.table.created_at_col'))
                     ->dateTime(FilamentFlexibleBlocksConfig::getPublishingDateFormatting())
                     ->sortable(),
-                PublishedColumn::create(),
+                PublishedColumn::create()
+                    ->sortable(),
             ])
             ->filters([
                 PublishedFilter::create(),
@@ -218,6 +230,38 @@ class PageResource extends Resource
             'index' => ListPages::route('/'),
             'create' => CreatePage::route('/create'),
             'edit' => EditPage::route('/{record:id}/edit'),
+        ];
+    }
+
+    public static function getGloballySearchableAttributes(): array
+    {
+        return [
+            'title',
+            'intro',
+            'content_blocks',
+            'seo_title',
+            'seo_description',
+            'seo_keywords'
+        ];
+    }
+
+    public static function getGlobalSearchResultTitle(Model $record): string
+    {
+        return $record->getTranslation('title', app()->getLocale());
+    }
+
+    public static function getGlobalSearchResultDetails(Model $record): array
+    {
+        $published = trans('filament-flexible-content-blocks::filament-flexible-content-blocks.columns.is_published_state_unpublished');
+        if ($record->isPublished()) {
+            $published = trans(
+                'filament-flexible-content-blocks::filament-flexible-content-blocks.columns.is_published_state_published'
+            );
+        }
+
+        return [
+            trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.intro_lbl') => Str::limit(strip_tags($record->intro)),
+            trans('filament-flexible-content-blocks::filament-flexible-content-blocks.columns.is_published') => $published
         ];
     }
 }

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -186,11 +186,12 @@ class PageResource extends Resource
         return $table
             ->columns([
                 TitleColumn::create()
-                ->searchable(query: function($query, $search) {
-                    $locale = app()->getLocale();
-                    $search = strtolower($search);
-                    return $query->whereRaw("LOWER(title->>'$.{$locale}') LIKE ?", ["%{$search}%"]);
-                }),
+                    ->searchable(query: function ($query, $search) {
+                        $locale = app()->getLocale();
+                        $search = strtolower($search);
+
+                        return $query->whereRaw("LOWER(title->>'$.{$locale}') LIKE ?", ["%{$search}%"]);
+                    }),
                 TextColumn::make('created_at')
                     ->label(flexiblePagesTrans('pages.table.created_at_col'))
                     ->dateTime(FilamentFlexibleBlocksConfig::getPublishingDateFormatting())
@@ -241,7 +242,7 @@ class PageResource extends Resource
             'content_blocks',
             'seo_title',
             'seo_description',
-            'seo_keywords'
+            'seo_keywords',
         ];
     }
 
@@ -261,7 +262,7 @@ class PageResource extends Resource
 
         return [
             trans('filament-flexible-content-blocks::filament-flexible-content-blocks.form_component.intro_lbl') => Str::limit(strip_tags($record->intro)),
-            trans('filament-flexible-content-blocks::filament-flexible-content-blocks.columns.is_published') => $published
+            trans('filament-flexible-content-blocks::filament-flexible-content-blocks.columns.is_published') => $published,
         ];
     }
 }


### PR DESCRIPTION
### Description
I added a search option on the resource list overview and global search in panel (see included screenshot)

- The global search looks for text in title, intro, content-blocks and seo title & description.

- On the resource page its (for now) only the title field.
- 
### TODO
Add search filter on the ListOverview that include fields not visible in the table.

<img width="798" height="477" alt="Screenshot 2025-08-08 at 15 30 20" src="https://github.com/user-attachments/assets/ed1a4f12-0757-462b-bc0a-5e22832494fc" />

### Reason for this change

It needed a search