### PR TITLE
Fix lazy loading violation on page tree and add canonical URL redirects

### DIFF
--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Gate;
 use Statikbe\FilamentFlexibleContentBlockPages\Facades\FilamentFlexibleContentBlockPages;
 use Statikbe\FilamentFlexibleContentBlockPages\Models\Page;
+use Statikbe\FilamentFlexibleContentBlocks\Models\Contracts\HasPageAttributes;
 
 class PageController extends AbstractSeoPageController
 {
@@ -18,6 +19,7 @@ class PageController extends AbstractSeoPageController
 
     public function index(Page $page)
     {
+        // If the page has a parent, it should be accessed via the parent or grandparent route instead.
         if ($page->hasParent()) {
             return redirect($page->getViewUrl(), Response::HTTP_MOVED_PERMANENTLY);
         }
@@ -62,19 +64,10 @@ class PageController extends AbstractSeoPageController
         return $this->renderPage($page);
     }
 
-    private function renderPage(Page $page)
+    protected function renderPage(Page $page)
     {
         // check if page is published:
-        /** @var class-string|null $pageModel */
-        $pageModel = FilamentFlexibleContentBlockPages::config()->getPageModel();
-        $viewUnpublishedPagesGate = FilamentFlexibleContentBlockPages::config()->getViewUnpublishedPagesGate($pageModel);
-
-        if (! Auth::user() || ! ($viewUnpublishedPagesGate && Gate::allows($viewUnpublishedPagesGate, $page))) {
-            if (! $page->isPublished()) {
-                SEOMeta::setRobots('noindex');
-                abort(Response::HTTP_GONE);
-            }
-        }
+        $this->abortIfUnpublished($page);
 
         // SEO
         $this->setBasicSEO($page);
@@ -86,7 +79,21 @@ class PageController extends AbstractSeoPageController
         ]);
     }
 
-    private function getTemplatePath(Page $page)
+    protected function abortIfUnpublished(HasPageAttributes $page)
+    {
+        /** @var class-string|null $pageModel */
+        $pageModel = FilamentFlexibleContentBlockPages::config()->getPageModel();
+        $viewUnpublishedPagesGate = FilamentFlexibleContentBlockPages::config()->getViewUnpublishedPagesGate($pageModel);
+
+        if (! Auth::user() || ! ($viewUnpublishedPagesGate && Gate::allows($viewUnpublishedPagesGate, $page))) {
+            if (! $page->isPublished()) {
+                SEOMeta::setRobots('noindex');
+                abort(Response::HTTP_GONE);
+            }
+        }
+    }
+
+    protected function getTemplatePath(Page $page)
     {
         // handle custom templates
         if ($page->code) {

--- a/src/Routes/LocalisedPageRouteHelper.php
+++ b/src/Routes/LocalisedPageRouteHelper.php
@@ -38,7 +38,9 @@ class LocalisedPageRouteHelper extends AbstractPageRouteHelper
             return LaravelLocalization::getLocalizedUrl($locale, static::ROUTE_HOME);
         }
 
-        $page->loadMissing('parent.parent');
+        if ($page->hasParent()) {
+            $page->loadMissing('parent.parent');
+        }
 
         $ancestorSlugs = [];
         $locale = $locale ?? app()->getLocale();

--- a/src/Routes/LocalisedPageRouteHelper.php
+++ b/src/Routes/LocalisedPageRouteHelper.php
@@ -38,6 +38,8 @@ class LocalisedPageRouteHelper extends AbstractPageRouteHelper
             return LaravelLocalization::getLocalizedUrl($locale, static::ROUTE_HOME);
         }
 
+        $page->loadMissing('parent.parent');
+
         $ancestorSlugs = [];
         $locale = $locale ?? app()->getLocale();
 


### PR DESCRIPTION
  - Fix LazyLoadingViolationException when rendering the page tree view by eager loading parent relationships within nested children in ManagePageTree::getWithRelationQuery()
  - Add loadMissing('parent.parent') safety net in LocalisedPageRouteHelper::getUrl(), consistent with PageRouteHelper
  - Add 301 redirects to canonical URLs when pages are accessed without their full parent hierarchy in the URL (e.g. /page-111 redirects to /page-1/page-11/page-111)
  - Extract render logic into private renderPage() method in PageController

### Description


### Reason for this change