### PR TITLE
Fix incorrect order to drop tables in tags table migration

### DIFF
--- a/database/migrations/create_filament_flexible_content_block_pages_redirects_table.php.stub
+++ b/database/migrations/create_filament_flexible_content_block_pages_redirects_table.php.stub
@@ -17,4 +17,9 @@ return new class extends Migration {
             $table->timestamps();
         });
     }
+
+    public function down()
+    {
+        Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getRedirectsTable());
+    }
 };

--- a/database/migrations/create_filament_flexible_content_block_pages_settings_table.php.stub
+++ b/database/migrations/create_filament_flexible_content_block_pages_settings_table.php.stub
@@ -19,4 +19,9 @@ return new class extends Migration {
             $table->timestamps();
         });
     }
+
+    public function down()
+    {
+        Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getSettingsTable());
+    }
 };

--- a/database/migrations/create_filament_flexible_content_block_pages_table.php.stub
+++ b/database/migrations/create_filament_flexible_content_block_pages_table.php.stub
@@ -98,4 +98,9 @@ return new class extends Migration
             $table->timestamps();
         });
     }
+
+    public function down()
+    {
+        Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getPagesTable());
+    }
 };

--- a/database/migrations/create_filament_flexible_content_block_tags_table.php.stub
+++ b/database/migrations/create_filament_flexible_content_block_tags_table.php.stub
@@ -56,8 +56,8 @@ return new class extends Migration
 
     public function down(): void
     {
+        Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getTaggablesTable());
         Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getTagsTable());
         Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getTagTypesTable());
-        Schema::dropIfExists(FilamentFlexibleContentBlockPages::config()->getTaggablesTable());
     }
 };


### PR DESCRIPTION
### Description
The `migrate:rollback` command didn't work after a fresh install, due to a asymmetric order for dropping the tables.

### Reason for this change
Restore behaviour in the `migrate:rollback` command.