### PR TITLE
 [INTLAR-232] preventing wrong usage of intro-field

### DIFF
--- a/config/filament-flexible-content-block-pages.php
+++ b/config/filament-flexible-content-block-pages.php
@@ -175,6 +175,20 @@ return [
                  */
                 'max_depth' => 2,
             ],
+
+            /*
+             | The toolbar buttons to enable for the 'intro' field of a page.
+             | When not configured, a limited set of buttons will be enabled by default.
+             */
+            'intro_toolbar_buttons' => [
+                'bold',
+                'italic',
+                'link',
+                'bulletList',
+                'orderedList',
+                'undo',
+                'redo',
+            ],
         ],
         // If you extend PageResource and want to use your own model, you can add your the extended page resource config for your own model here...
     ],

--- a/resources/lang/en/filament-flexible-content-block-pages.php
+++ b/resources/lang/en/filament-flexible-content-block-pages.php
@@ -13,6 +13,9 @@ return [
             'overview' => 'Overview',
             'advanced' => 'Advanced',
         ],
+        'fields' => [
+            'intro_help' => 'Optional short introduction/description of the page. Extensive page content, on the other hand, can be managed in the "Content" tab.',
+        ],
         'table' => [
             'created_at_col' => 'Created at',
             'updated_at_col' => 'Updated at',

--- a/resources/lang/fr/filament-flexible-content-block-pages.php
+++ b/resources/lang/fr/filament-flexible-content-block-pages.php
@@ -13,6 +13,9 @@ return [
             'overview' => 'Vue d\'ensemble',
             'advanced' => 'Avancé',
         ],
+        'fields' => [
+            'intro_help' => 'Brève introduction/description facultative de la page. Le contenu détaillé de la page, quant à lui, peut être géré dans l\'onglet "Contenu".',
+        ],
         'table' => [
             'created_at_col' => 'Créé le',
             'updated_at_col' => 'Modifié le',

--- a/resources/lang/nl/filament-flexible-content-block-pages.php
+++ b/resources/lang/nl/filament-flexible-content-block-pages.php
@@ -13,6 +13,9 @@ return [
             'overview' => 'Overzicht',
             'advanced' => 'Geavanceerd',
         ],
+        'fields' => [
+            'intro_help' => 'Optionele korte introductie/beschrijving van de pagina. Uitgebreide pagina-inhoud daarentegen kan worden beheerd in de "Inhoud" tab.',
+        ],
         'table' => [
             'created_at_col' => 'Aangemaakt op',
             'updated_at_col' => 'Aangepast op',

--- a/src/FilamentFlexibleContentBlockPagesConfig.php
+++ b/src/FilamentFlexibleContentBlockPagesConfig.php
@@ -38,6 +38,16 @@ class FilamentFlexibleContentBlockPagesConfig
 
     const TYPE_MENU_ITEM = 'menu_items';
 
+    const DEFAULT_INTRO_TOOLBAR_BUTTONS = [
+        'bold',
+        'italic',
+        'link',
+        'bulletList',
+        'orderedList',
+        'undo',
+        'redo',
+    ];
+
     private string $pageModel;
 
     private string $redirectModel;
@@ -361,6 +371,14 @@ class FilamentFlexibleContentBlockPagesConfig
     public function isEditPageButtonEnabled(string $modelClass): bool
     {
         return $this->packageConfig("page_resource.{$modelClass}.enable_edit_page_button", true);
+    }
+
+    /**
+     * @param  class-string<Model>  $modelClass
+     */
+    public function getIntroToolbarButtons(string $modelClass): array
+    {
+        return $this->packageConfig("page_resource.{$modelClass}.intro_toolbar_buttons", static::DEFAULT_INTRO_TOOLBAR_BUTTONS);
     }
 
     /**

--- a/src/Resources/PageResource/Schemas/PageFormSchema.php
+++ b/src/Resources/PageResource/Schemas/PageFormSchema.php
@@ -58,7 +58,7 @@ class PageFormSchema
 
         $fields = [
             TitleField::create(true),
-            IntroField::create(),
+            static::getPageIntroField(),
             HeroImageSection::create(true, FilamentFlexibleContentBlockPages::config()->isHeroVideoUrlEnabled($modelClass)),
         ];
 
@@ -117,5 +117,17 @@ class PageFormSchema
         }
 
         return $fields;
+    }
+
+    public static function getPageIntroField(): IntroField
+    {
+        return IntroField::create()
+            ->helperText(flexiblePagesTrans('pages.fields.intro_help'))
+            ->toolbarButtons(static::getIntroToolbarButtons());
+    }
+
+    private static function getIntroToolbarButtons(): array
+    {
+        return FilamentFlexibleContentBlockPages::config()->getIntroToolbarButtons(PageResource::getModel());
     }
 }


### PR DESCRIPTION
Preventing wrong usage of intro-field (which is regularly used for storing actual page content) by adding a helper text and by default limiting its available toolbar buttons.